### PR TITLE
Add JSON Schema for ERDS Evidence

### DIFF
--- a/docs/qerds/data-schemas/erds-evidence.json
+++ b/docs/qerds/data-schemas/erds-evidence.json
@@ -1,0 +1,534 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://uri.etsi.org/19522/v1#/Evidence",
+  "title": "ETSI EN 319 522-3 V1.2.1 Evidence",
+  "description": "JSON Schema for Electronic Registered Delivery Service (ERDS) Evidence, structurally equivalent to the EvidenceType XML Schema in ETSI EN 319 522-3 V1.2.1 (namespace http://uri.etsi.org/19522/v1#). XML attributes are represented as properties; repeating elements are represented as arrays.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "EN319522v1.1.1",
+      "description": "Schema version (required XML attribute)."
+    },
+    "evidenceIdentifier": {
+      "type": "string",
+      "description": "String identifier for this evidence instance."
+    },
+    "erdsEventId": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI identifying the ERDS event that triggered production of this evidence (Table 2).",
+      "enum": [
+        "http://uri.etsi.org/19522/Event/SubmissionAcceptance",
+        "http://uri.etsi.org/19522/Event/SubmissionRejection",
+        "http://uri.etsi.org/19522/Event/RelayAcceptance",
+        "http://uri.etsi.org/19522/Event/RelayRejection",
+        "http://uri.etsi.org/19522/Event/RelayFailure",
+        "http://uri.etsi.org/19522/Event/NotificationForAcceptance",
+        "http://uri.etsi.org/19522/Event/NotificationForAcceptanceFailure",
+        "http://uri.etsi.org/19522/Event/ConsignmentAcceptance",
+        "http://uri.etsi.org/19522/Event/ConsignmentRejection",
+        "http://uri.etsi.org/19522/Event/AcceptanceRejectionExpiry",
+        "http://uri.etsi.org/19522/Event/NotificationDelivered",
+        "http://uri.etsi.org/19522/Event/ContentConsignment",
+        "http://uri.etsi.org/19522/Event/ContentConsignmentFailure",
+        "http://uri.etsi.org/19522/Event/ConsignmentNotification",
+        "http://uri.etsi.org/19522/Event/ConsignmentNotificationFailure",
+        "http://uri.etsi.org/19522/Event/NotificationAccessTracking",
+        "http://uri.etsi.org/19522/Event/ContentAccessTracking",
+        "http://uri.etsi.org/19522/Event/ContentHandover",
+        "http://uri.etsi.org/19522/Event/ContentHandoverFailure",
+        "http://uri.etsi.org/19522/Event/RelayToNonERDS",
+        "http://uri.etsi.org/19522/Event/RelayToNonERDSFailure",
+        "http://uri.etsi.org/19522/Event/ReceivedFromNonERDS"
+      ]
+    },
+    "eventReasons": {
+      "type": "object",
+      "description": "Container for one or more event reasons.",
+      "properties": {
+        "eventReason": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "description": "A single reason that caused the ERDS event. code is a URI; details provides optional elaboration.",
+            "properties": {
+              "code": {
+                "type": "string",
+                "format": "uri",
+                "description": "URI identifying the event reason."
+              },
+              "details": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Optional additional details about the reason."
+              }
+            },
+            "required": ["code"]
+          }
+        }
+      },
+      "required": ["eventReason"]
+    },
+    "eventTime": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Date and time of the event."
+    },
+    "evidenceIssuerPolicyId": {
+      "type": "object",
+      "description": "One or more policy identifiers (URIs, or URNs per RFC 3061 for OID-based policies).",
+      "properties": {
+        "policyId": {
+          "type": "array",
+          "items": { "type": "string", "format": "uri" },
+          "minItems": 1
+        }
+      },
+      "required": ["policyId"]
+    },
+    "evidenceIssuerDetails": {
+      "$ref": "#/definitions/EntityDetailsType",
+      "description": "Details of the entity that issued this evidence."
+    },
+    "senderDetails": {
+      "$ref": "#/definitions/UserDetailsType",
+      "description": "Details of the message sender."
+    },
+    "senderDelegateDetails": {
+      "$ref": "#/definitions/UserDetailsType",
+      "description": "Details of a delegate acting on behalf of the sender."
+    },
+    "recipientDetails": {
+      "type": "array",
+      "description": "One or more recipients of the message.",
+      "items": { "$ref": "#/definitions/UserDetailsType" },
+      "minItems": 1
+    },
+    "recipientsDelegateDetails": {
+      "type": "array",
+      "description": "Zero or more delegates acting on behalf of recipients.",
+      "items": {
+        "allOf": [
+          { "$ref": "#/definitions/UserDetailsType" },
+          {
+            "type": "object",
+            "description": "Extends UserDetailsType with the list of recipients for whom this delegate acts.",
+            "properties": {
+              "delegatingRecipients": {
+                "type": "array",
+                "items": { "type": "integer" },
+                "description": "Indices (integers) of recipientDetails entries for which this delegate acts. Represented as xs:list of xs:integer in XSD."
+              }
+            },
+            "required": ["delegatingRecipients"]
+          }
+        ]
+      }
+    },
+    "submissionTime": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Time at which the message was submitted."
+    },
+    "evidenceRefersToRecipient": {
+      "type": "integer",
+      "description": "1-based index into recipientDetails identifying the specific recipient this evidence pertains to."
+    },
+    "messageIdentifier": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Non-empty string identifying the message."
+    },
+    "userContentInfo": {
+      "type": "object",
+      "description": "Metadata about the user message content.",
+      "properties": {
+        "appLayerIdentifier": {
+          "type": "string",
+          "description": "Optional application-layer identifier for the message."
+        },
+        "composingParts": {
+          "type": "integer",
+          "description": "Optional total number of parts composing the message."
+        },
+        "partsInfo": {
+          "type": "array",
+          "description": "One or more partInfo elements describing individual content parts.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "description": "Metadata for a single content part, including an optional digest.",
+            "properties": {
+              "identifier": {
+                "type": "string",
+                "description": "Identifier for this content part."
+              },
+              "contentType": {
+                "type": "string",
+                "description": "MIME type or other content type designation."
+              },
+              "digestMethod": {
+                "type": "object",
+                "description": "Algorithm used to compute the digest (ds:DigestMethod).",
+                "properties": {
+                  "algorithm": { "type": "string", "format": "uri" }
+                },
+                "required": ["algorithm"]
+              },
+              "digestValue": {
+                "type": "string",
+                "contentEncoding": "base64",
+                "description": "Base64-encoded digest value (ds:DigestValue)."
+              }
+            },
+            "required": ["identifier", "contentType"]
+          }
+        }
+      },
+      "required": ["partsInfo"],
+      "examples": [
+        {
+          "appLayerIdentifier": "contract",
+          "composingParts": 1,
+          "partsInfo": [
+            {
+              "identifier": "contract.pdf",
+              "contentType": "application/pdf",
+              "digestMethod": {
+                "algorithm": "http://www.w3.org/2001/04/xmlenc#sha256"
+              },
+              "digestValue": "ZXhhbXBsZWRpZ2VzdHZhbHVlZm9yY29udHJhY3RwZGY="
+            }
+          ]
+        }
+      ]
+    },
+    "externalErdsDetails": {
+      "$ref": "#/definitions/EntityDetailsType",
+      "description": "Details of an external ERDS involved in the delivery."
+    },
+    "forwardedToExternalSystem": {
+      "type": "string",
+      "description": "Identifier of an external system to which the message was forwarded."
+    },
+    "transactionLogInformation": {
+      "type": "object",
+      "description": "References to one or more external transaction logs.",
+      "properties": {
+        "transactionLog": {
+          "type": "array",
+          "items": {},
+          "minItems": 1,
+          "description": "One or more transaction log entries (open content)."
+        }
+      },
+      "required": ["transactionLog"]
+    },
+    "extensions": {
+      "type": "array",
+      "description": "One or more extension elements.",
+      "minItems": 1,
+      "items": {
+        "allOf": [
+          {},
+          {
+            "type": "object",
+            "description": "Extension element with an optional criticality flag (isCritical XML attribute).",
+            "properties": {
+              "isCritical": {
+                "type": "boolean",
+                "description": "When true, processors that do not understand this extension MUST reject processing."
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "required": [
+    "version",
+    "evidenceIdentifier",
+    "erdsEventId",
+    "eventTime",
+    "evidenceIssuerDetails",
+    "senderDetails",
+    "recipientDetails"
+  ],
+  "definitions": {
+    "EntityDetailsType": {
+      "type": "object",
+      "description": "Identity and optional certificate details for an entity (issuer or external ERDS).",
+      "properties": {
+        "identity": { "$ref": "#/definitions/IdentityAttributesType" },
+        "certificateDetails": {
+          "type": "array",
+          "description": "One to three certificate representations, each being an X.509 certificate or a certificate ID (xs:choice maxOccurs='3').",
+          "minItems": 1,
+          "maxItems": 3,
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "description": "DER-encoded X.509 certificate in Base64.",
+                "properties": {
+                  "x509Certificate": {
+                    "type": "string",
+                    "contentEncoding": "base64"
+                  }
+                },
+                "required": ["x509Certificate"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "description": "Certificate identified by digest and optional issuer/serial.",
+                "properties": {
+                  "certId": { "$ref": "#/definitions/CertIDTypeV2" }
+                },
+                "required": ["certId"],
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "any": {
+          "description": "Extension point for additional entity data."
+        }
+      },
+      "required": ["identity"]
+    },
+
+    "IdentityAttributesType": {
+      "type": "object",
+      "description": "One or more SAML Attributes describing the entity's identity.",
+      "properties": {
+        "attribute": {
+          "type": "array",
+          "description": "SAML 2.0 Attributes (saml:Attribute).",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "description": "SAML 2.0 saml:Attribute element.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Attribute name (required)."
+              },
+              "nameFormat": {
+                "type": "string",
+                "format": "uri",
+                "description": "URI identifying the name format."
+              },
+              "friendlyName": {
+                "type": "string",
+                "description": "Human-readable name for the attribute."
+              },
+              "attributeValue": {
+                "type": "array",
+                "items": {},
+                "description": "Zero or more attribute values (saml:AttributeValue); each value may be any type."
+              }
+            },
+            "required": ["name"]
+          }
+        }
+      },
+      "required": ["attribute"]
+    },
+
+    "CertIDTypeV2": {
+      "type": "object",
+      "description": "Certificate identifier comprising a digest and an optional issuer/serial (V2 variant per RFC 5652).",
+      "properties": {
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "Optional URI locating the certificate."
+        },
+        "certDigest": {
+          "type": "object",
+          "description": "Digest of the certificate (ds:DigestMethod + ds:DigestValue).",
+          "properties": {
+            "digestMethod": {
+              "type": "object",
+              "description": "XML digital signature DigestMethod: identifies the digest algorithm by URI.",
+              "properties": {
+                "algorithm": { "type": "string", "format": "uri" }
+              },
+              "required": ["algorithm"]
+            },
+            "digestValue": { "type": "string", "contentEncoding": "base64" }
+          },
+          "required": ["digestMethod", "digestValue"]
+        },
+        "issuerSerialV2": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "DER-encoded IssuerSerial (V2) identifying the certificate issuer and serial number."
+        }
+      },
+      "required": ["certDigest"]
+    },
+
+    "UserDetailsType": {
+      "type": "object",
+      "description": "Identity, identifier, and assurance details for a user (sender, recipient, or delegate).",
+      "properties": {
+        "identity": { "$ref": "#/definitions/IdentityAttributesType" },
+        "identifier": {
+          "type": "object",
+          "description": "A non-empty string identifier within a named scheme (xs:simpleContent extension).",
+          "properties": {
+            "value": {
+              "type": "string",
+              "minLength": 1,
+              "description": "The identifier value."
+            },
+            "identifierSchemeName": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Name of the identification scheme (required XML attribute)."
+            }
+          },
+          "required": ["value", "identifierSchemeName"]
+        },
+        "assuranceLevelsDetails": {
+          "description": "Assurance level information expressed as one of two alternative structures (xs:choice of two sequences).",
+          "oneOf": [
+            {
+              "type": "object",
+              "description": "Option 1: a global assurance level together with authentication details.",
+              "properties": {
+                "globalAssuranceLevel": {
+                  "$ref": "#/definitions/AssuranceLevelDetailsType"
+                },
+                "authenticationDetails": {
+                  "$ref": "#/definitions/AuthenticationDetailsType"
+                }
+              },
+              "required": ["globalAssuranceLevel", "authenticationDetails"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "description": "Option 2: per-factor assurance levels (authentication, identity proof, optional federation).",
+              "properties": {
+                "authenticationDetsAndAssuranceLevel": {
+                  "type": "object",
+                  "description": "An assurance level paired with optional authentication details.",
+                  "properties": {
+                    "assuranceLevel": {
+                      "$ref": "#/definitions/AssuranceLevelDetailsType"
+                    },
+                    "authenticationDetails": {
+                      "$ref": "#/definitions/AuthenticationDetailsType"
+                    }
+                  },
+                  "required": ["assuranceLevel"]
+                },
+                "identityProofAssuranceLevel": {
+                  "$ref": "#/definitions/AssuranceLevelDetailsType"
+                },
+                "federationAssuranceLevel": {
+                  "$ref": "#/definitions/AssuranceLevelDetailsType"
+                }
+              },
+              "required": [
+                "authenticationDetsAndAssuranceLevel",
+                "identityProofAssuranceLevel"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
+
+    "AssuranceLevelDetailsType": {
+      "type": "object",
+      "description": "Details about a single assurance level, including an optional policy reference.",
+      "properties": {
+        "assuranceLevel": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI identifying the assurance level."
+        },
+        "policyId": {
+          "type": "string",
+          "format": "uri",
+          "description": "Optional URI identifying an applicable policy."
+        },
+        "policyIdDetails": {
+          "type": "string",
+          "description": "Optional textual details about the policy."
+        },
+        "policyIdDetailsResources": {
+          "type": "array",
+          "description": "Optional multilingual URIs for policy detail resources.",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "description": "A URI tagged with a mandatory language code (xml:lang attribute).",
+            "properties": {
+              "value": { "type": "string", "format": "uri", "minLength": 1 },
+              "lang": {
+                "type": "string",
+                "description": "BCP 47 language tag (xml:lang)."
+              }
+            },
+            "required": ["value", "lang"]
+          }
+        }
+      },
+      "required": ["assuranceLevel"]
+    },
+
+    "AuthenticationDetailsType": {
+      "description": "Authentication details expressed as one of four alternatives: a SAML Assertion, an OAuth2 token, explicit time/method, or an opaque 'other' value.",
+      "oneOf": [
+        {
+          "type": "object",
+          "description": "SAML 2.0 Assertion.",
+          "properties": {
+            "assertion": {
+              "type": "object",
+              "description": "SAML 2.0 saml:Assertion element (externally defined)."
+            }
+          },
+          "required": ["assertion"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "OAuth2 token (any structure).",
+          "properties": {
+            "oAuth2": {}
+          },
+          "required": ["oAuth2"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "Explicit authentication time and method URI.",
+          "properties": {
+            "authenticationTime": { "type": "string", "format": "date-time" },
+            "authenticationMethod": { "type": "string", "format": "uri" }
+          },
+          "required": ["authenticationTime", "authenticationMethod"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "description": "Any other authentication details.",
+          "properties": {
+            "other": {}
+          },
+          "required": ["other"],
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}

--- a/docs/qerds/data-schemas/erds-evidence.json
+++ b/docs/qerds/data-schemas/erds-evidence.json
@@ -7,8 +7,11 @@
   "properties": {
     "version": {
       "type": "string",
-      "const": "EN319522v1.1.1",
       "description": "Schema version (required XML attribute)."
+    },
+    "id": {
+      "type": "string",
+      "description": "Optional XML attribute Id (xs:ID)."
     },
     "evidenceIdentifier": {
       "type": "string",
@@ -17,31 +20,7 @@
     "erdsEventId": {
       "type": "string",
       "format": "uri",
-      "description": "URI identifying the ERDS event that triggered production of this evidence (Table 2).",
-      "enum": [
-        "http://uri.etsi.org/19522/Event/SubmissionAcceptance",
-        "http://uri.etsi.org/19522/Event/SubmissionRejection",
-        "http://uri.etsi.org/19522/Event/RelayAcceptance",
-        "http://uri.etsi.org/19522/Event/RelayRejection",
-        "http://uri.etsi.org/19522/Event/RelayFailure",
-        "http://uri.etsi.org/19522/Event/NotificationForAcceptance",
-        "http://uri.etsi.org/19522/Event/NotificationForAcceptanceFailure",
-        "http://uri.etsi.org/19522/Event/ConsignmentAcceptance",
-        "http://uri.etsi.org/19522/Event/ConsignmentRejection",
-        "http://uri.etsi.org/19522/Event/AcceptanceRejectionExpiry",
-        "http://uri.etsi.org/19522/Event/NotificationDelivered",
-        "http://uri.etsi.org/19522/Event/ContentConsignment",
-        "http://uri.etsi.org/19522/Event/ContentConsignmentFailure",
-        "http://uri.etsi.org/19522/Event/ConsignmentNotification",
-        "http://uri.etsi.org/19522/Event/ConsignmentNotificationFailure",
-        "http://uri.etsi.org/19522/Event/NotificationAccessTracking",
-        "http://uri.etsi.org/19522/Event/ContentAccessTracking",
-        "http://uri.etsi.org/19522/Event/ContentHandover",
-        "http://uri.etsi.org/19522/Event/ContentHandoverFailure",
-        "http://uri.etsi.org/19522/Event/RelayToNonERDS",
-        "http://uri.etsi.org/19522/Event/RelayToNonERDSFailure",
-        "http://uri.etsi.org/19522/Event/ReceivedFromNonERDS"
-      ]
+      "description": "URI identifying the ERDS event that triggered production of this evidence (Table 2)."
     },
     "eventReasons": {
       "type": "object",
@@ -245,6 +224,10 @@
           }
         ]
       }
+    },
+    "jadesSignature": {
+      "$ref": "#/definitions/JAdESSignature",
+      "description": "Optional JAdES signature replacing the XML ds:Signature."
     }
   },
   "required": [
@@ -264,7 +247,7 @@
         "identity": { "$ref": "#/definitions/IdentityAttributesType" },
         "certificateDetails": {
           "type": "array",
-          "description": "One to three certificate representations, each being an X.509 certificate or a certificate ID (xs:choice maxOccurs='3').",
+          "description": "One to three certificate representations, each being an X.509 certificate, a certificate ID, or a certificate ID and signature details (xs:choice maxOccurs='3').",
           "minItems": 1,
           "maxItems": 3,
           "items": {
@@ -288,6 +271,15 @@
                   "certId": { "$ref": "#/definitions/CertIDTypeV2" }
                 },
                 "required": ["certId"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "description": "Certificate identified by digest and accompanied by signature details.",
+                "properties": {
+                  "certIdAndSignature": { "$ref": "#/definitions/CertIDAndSignatureType" }
+                },
+                "required": ["certIdAndSignature"],
                 "additionalProperties": false
               }
             ]
@@ -529,6 +521,955 @@
           "additionalProperties": false
         }
       ]
+    },
+    "CertSignatureDetailsType": {
+        "type": "object",
+        "description": "Signature details associated with a certificate reference.",
+        "properties": {
+            "signatureAlgorithm": {
+                "type": "string",
+                "format": "uri",
+                "description": "URI identifying the signature algorithm."
+            },
+            "signatureValue": {
+                "type": "string",
+                "contentEncoding": "base64",
+                "description": "Base64-encoded signature value."
+            }
+        },
+        "required": [
+            "signatureAlgorithm",
+            "signatureValue"
+        ]
+    },
+    "CertIDAndSignatureType": {
+        "type": "object",
+        "description": "Certificate identifier together with signature details.",
+        "properties": {
+            "certId": {
+                "$ref": "#/definitions/CertIDTypeV2"
+            },
+            "certSignatureDetails": {
+                "$ref": "#/definitions/CertSignatureDetailsType"
+            }
+        },
+        "required": [
+            "certId",
+            "certSignatureDetails"
+        ]
+    },
+    "Base64UrlString": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9_-]*$",
+        "description": "Base64url-encoded string."
+    },
+    "JAdESHeader": {
+        "type": "object",
+        "description": "Decoded JAdES/JWS protected header represented as JSON for validation convenience.",
+        "properties": {
+            "alg": {
+                "type": "string",
+                "description": "JWS algorithm."
+            },
+            "typ": {
+                "type": "string",
+                "description": "Type header parameter."
+            },
+            "cty": {
+                "type": "string",
+                "description": "Content type header parameter."
+            },
+            "kid": {
+                "type": "string",
+                "description": "Key identifier."
+            },
+            "crit": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "description": "Critical header parameter names."
+            },
+            "b64": {
+                "type": "boolean",
+                "description": "JWS b64 header parameter."
+            },
+            "x5c": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "contentEncoding": "base64"
+                },
+                "description": "Certificate chain."
+            },
+            "x5t#S256": {
+                "type": "string",
+                "description": "SHA-256 certificate thumbprint in base64url form."
+            },
+            "sigT": {
+                "type": "object",
+                "description": "Optional JAdES signature time information."
+            },
+            "sigD": {
+                "type": "object",
+                "description": "Optional JAdES detached payload descriptor."
+            },
+            "etsiU": {
+                "type": "object",
+                "description": "Optional JAdES unprotected header content."
+            }
+        }
+    },
+    "JAdESCompactDetached": {
+        "type": "object",
+        "description": "Detached compact JAdES/JWS representation.",
+        "properties": {
+            "protected": {
+                "$ref": "#/definitions/Base64UrlString",
+                "description": "Base64url-encoded protected header."
+            },
+            "decodedProtectedHeader": {
+                "$ref": "#/definitions/JAdESHeader"
+            },
+            "signature": {
+                "$ref": "#/definitions/Base64UrlString",
+                "description": "Base64url-encoded signature value."
+            }
+        },
+        "required": [
+            "protected",
+            "signature"
+        ]
+    },
+    "JWSFlattenedJsonSerialization": {
+        "type": "object",
+        "description": "Flattened JWS JSON serialization for JAdES.",
+        "properties": {
+            "protected": {
+                "$ref": "#/definitions/Base64UrlString"
+            },
+            "decodedProtectedHeader": {
+                "$ref": "#/definitions/JAdESHeader"
+            },
+            "header": {
+                "type": "object",
+                "description": "Unprotected header parameters."
+            },
+            "signature": {
+                "$ref": "#/definitions/Base64UrlString"
+            }
+        },
+        "required": [
+            "signature"
+        ]
+    },
+    "JWSGeneralJsonSerialization": {
+        "type": "object",
+        "description": "General JWS JSON serialization for JAdES.",
+        "properties": {
+            "signatures": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "protected": {
+                            "$ref": "#/definitions/Base64UrlString"
+                        },
+                        "decodedProtectedHeader": {
+                            "$ref": "#/definitions/JAdESHeader"
+                        },
+                        "header": {
+                            "type": "object"
+                        },
+                        "signature": {
+                            "$ref": "#/definitions/Base64UrlString"
+                        }
+                    },
+                    "required": [
+                        "signature"
+                    ]
+                }
+            }
+        },
+        "required": [
+            "signatures"
+        ]
+    },
+    "JAdESSignature": {
+        "description": "JAdES signature replacing the XML ds:Signature element.",
+        "oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "compactDetached": {
+                        "$ref": "#/definitions/JAdESCompactDetached"
+                    }
+                },
+                "required": [
+                    "compactDetached"
+                ],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "flattenedJson": {
+                        "$ref": "#/definitions/JWSFlattenedJsonSerialization"
+                    }
+                },
+                "required": [
+                    "flattenedJson"
+                ],
+                "additionalProperties": false
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "generalJson": {
+                        "$ref": "#/definitions/JWSGeneralJsonSerialization"
+                    }
+                },
+                "required": [
+                    "generalJson"
+                ],
+                "additionalProperties": false
+            }
+        ]
+    },
+    "AnyType": {
+        "description": "Open-content placeholder corresponding to xsd:anyType.",
+        "type": [
+            "object",
+            "array",
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "null"
+        ]
+    },
+    "NonEmptyStringType": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Non-empty string."
+    },
+    "NonEmptyURIType": {
+        "type": "string",
+        "format": "uri",
+        "minLength": 1,
+        "description": "Non-empty URI."
+    },
+    "NonEmptyAttributedURIType": {
+        "type": "object",
+        "description": "Non-empty URI with optional lang and scheme attributes.",
+        "properties": {
+            "value": {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1
+            },
+            "lang": {
+                "type": "string",
+                "description": "Language tag corresponding to xml:lang when applicable."
+            },
+            "scheme": {
+                "type": "string",
+                "description": "Optional scheme attribute from the XSD type."
+            }
+        },
+        "required": [
+            "value"
+        ]
+    },
+    "AttributedNonEmptyStringType": {
+        "type": "object",
+        "description": "Non-empty string with required type attribute.",
+        "properties": {
+            "value": {
+                "type": "string",
+                "minLength": 1
+            },
+            "type": {
+                "type": "string",
+                "minLength": 1
+            }
+        },
+        "required": [
+            "value",
+            "type"
+        ]
+    },
+    "MessageIdentifierType": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Non-empty message identifier."
+    },
+    "DigestAlgAndValueType": {
+        "type": "object",
+        "description": "Digest composed of ds:DigestMethod and ds:DigestValue.",
+        "properties": {
+            "digestMethod": {
+                "type": "object",
+                "description": "XML digital signature DigestMethod: identifies the digest algorithm by URI.",
+                "properties": {
+                    "algorithm": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "required": [
+                    "algorithm"
+                ]
+            },
+            "digestValue": {
+                "type": "string",
+                "contentEncoding": "base64",
+                "description": "Base64-encoded digest value (ds:DigestValue)."
+            }
+        },
+        "required": [
+            "digestMethod",
+            "digestValue"
+        ]
+    },
+    "ConsignmentModeType": {
+        "type": "string",
+        "format": "uri",
+        "description": "Consignment mode value from the XSD model.",
+        "enum": [
+            "http://uri.etsi.org/19522/v1#/consignment/basic",
+            "http://uri.etsi.org/19522/v1#/consignment/consent",
+            "http://uri.etsi.org/19522/v1#/consignment/signed",
+            "http://uri.etsi.org/19522/v1#/consignment/other"
+        ]
+    },
+    "ERDSMessageTypeType": {
+        "type": "string",
+        "format": "uri",
+        "description": "ERDS message type value from the XSD model.",
+        "enum": [
+            "http://uri.etsi.org/19522/v1#/ERDMessageType/dispatch",
+            "http://uri.etsi.org/19522/v1#/ERDMessageType/receipt",
+            "http://uri.etsi.org/19522/v1#/ERDMessageType/serviceInfo",
+            "http://uri.etsi.org/19522/v1#/ERDMessageType/payload"
+        ]
+    },
+    "RelayMetadataType": {
+        "type": "object",
+        "description": "Supplementary JSON projection of RelayMetadataType from the XSD.",
+        "properties": {
+            "version": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Schema version (required XML attribute)."
+            },
+            "messageIdentifier": {
+                "$ref": "#/definitions/MessageIdentifierType",
+                "description": "Non-empty string identifying the message."
+            },
+            "erdMessageType": {
+                "$ref": "#/definitions/ERDSMessageTypeType",
+                "description": "Type of ERDS relay message."
+            },
+            "inReplyTo": {
+                "$ref": "#/definitions/MessageIdentifierType",
+                "description": "Optional message identifier to which this relay metadata refers."
+            },
+            "relayTime": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Time at which the relay occurred."
+            },
+            "expirationTime": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Optional expiration time."
+            },
+            "scheduledDeliveryTime": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Optional scheduled delivery time."
+            },
+            "senderId": {
+                "$ref": "#/definitions/AttributedNonEmptyStringType",
+                "description": "Identifier of the sender entity."
+            },
+            "replyTo": {
+                "$ref": "#/definitions/AttributedNonEmptyStringType",
+                "description": "Optional reply-to entity identifier."
+            },
+            "recipientId": {
+                "$ref": "#/definitions/AttributedNonEmptyStringType",
+                "description": "Identifier of the recipient entity."
+            },
+            "userContentInfo": {
+                "$ref": "#/definitions/UserContentInfoType",
+                "description": "Metadata about the user message content."
+            },
+            "requiredAssuranceLevel": {
+                "$ref": "#/definitions/AssuranceLevelDetailsType",
+                "description": "Optional required assurance level."
+            },
+            "applicablePolicy": {
+                "type": "object",
+                "description": "One or more policy identifiers (URIs, or URNs per RFC 3061 for OID-based policies).",
+                "properties": {
+                    "policyId": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "minItems": 1
+                    }
+                },
+                "required": [
+                    "policyId"
+                ]
+            },
+            "requestedConsignmentMode": {
+                "$ref": "#/definitions/ConsigmentModeType",
+                "description": "Requested consignment mode."
+            },
+            "extensions": {
+                "$ref": "#/definitions/ExtensionsType",
+                "description": "Optional extensions."
+            },
+            "jadesSignature": {
+                "$ref": "#/definitions/JAdESSignature",
+                "description": "Optional JAdES signature replacing the XML ds:Signature element."
+            }
+        },
+        "required": [
+            "version",
+            "messageIdentifier",
+            "erdMessageType",
+            "senderId",
+            "recipientId",
+            "userContentInfo"
+        ]
+    },
+    "ERDSMetadataType": {
+        "type": "object",
+        "description": "Supplementary JSON projection of ERDSMetadataType from the XSD.",
+        "properties": {
+            "version": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Schema version (required XML attribute)."
+            },
+            "erdsId": {
+                "$ref": "#/definitions/AttributedNonEmptyStringType",
+                "description": "Identifier of the ERDS entity."
+            },
+            "erdsDomain": {
+                "type": "string",
+                "description": "ERDS domain."
+            },
+            "erdsGoverningBody": {
+                "type": "string",
+                "description": "ERDS governing body."
+            },
+            "erdsProfileSupported": {
+                "type": "string",
+                "format": "uri",
+                "description": "Supported ERDS profile URI."
+            },
+            "erdsMetadataRepository": {
+                "type": "string",
+                "format": "uri",
+                "description": "Optional metadata repository URI."
+            },
+            "erdsEuQualifiedIndicator": {
+                "type": "boolean",
+                "description": "Optional EU qualified indicator."
+            },
+            "erdsTlsLocation": {
+                "type": "string",
+                "format": "uri",
+                "description": "Optional TLS location URI."
+            },
+            "erdsRootCaCertLocation": {
+                "type": "string",
+                "format": "uri",
+                "description": "Optional root CA certificate location URI."
+            },
+            "erdsExpiryDateAndTimeSupport": {
+                "type": "boolean",
+                "description": "Whether expiry date and time is supported."
+            },
+            "erdsScheduledDeliverySupport": {
+                "type": "boolean",
+                "description": "Whether scheduled delivery is supported."
+            },
+            "erdsAssuranceLevelsSupported": {
+                "$ref": "#/definitions/AssuranceLevelDetailsType",
+                "description": "Optional supported assurance levels."
+            },
+            "erdsPolicySupport": {
+                "type": "object",
+                "description": "One or more policy identifiers (URIs, or URNs per RFC 3061 for OID-based policies).",
+                "properties": {
+                    "policyId": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "minItems": 1
+                    }
+                },
+                "required": [
+                    "policyId"
+                ]
+            },
+            "erdsSupportedConsignmentModes": {
+                "$ref": "#/definitions/ConsigmentModeType",
+                "description": "Optional supported consignment mode."
+            }
+        },
+        "required": [
+            "version",
+            "erdsId",
+            "erdsDomain",
+            "erdsGoverningBody",
+            "erdsProfileSupported",
+            "erdsExpiryDateAndTimeSupport",
+            "erdsScheduledDeliverySupport"
+        ]
+    },
+    "ExtensionsType": {
+        "type": "object",
+        "properties": {
+            "extension": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "$ref": "#/definitions/ExtensionType"
+                }
+            }
+        },
+        "required": [
+            "extension"
+        ],
+        "description": "Container corresponding to the XSD ExtensionsType."
+    },
+    "ExtensionType": {
+        "allOf": [
+            {
+                "$ref": "#/definitions/AnyType"
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "isCritical": {
+                        "type": "boolean",
+                        "description": "Criticality flag."
+                    }
+                },
+                "description": "Supplementary JSON projection of an extension element."
+            }
+        ]
+    },
+    "NonEmptyMultiLangURIType": {
+        "type": "object",
+        "description": "Non-empty URI with required language tag.",
+        "properties": {
+            "value": {
+                "type": "string",
+                "format": "uri",
+                "minLength": 1
+            },
+            "lang": {
+                "type": "string",
+                "description": "BCP 47 language tag (xml:lang)."
+            }
+        },
+        "required": [
+            "value",
+            "lang"
+        ]
+    },
+    "NonEmptyMultiLangURIListType": {
+        "type": "object",
+        "description": "Container for one or more multilingual URIs.",
+        "properties": {
+            "uri": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "$ref": "#/definitions/NonEmptyMultiLangURIType"
+                }
+            }
+        },
+        "required": [
+            "uri"
+        ]
+    },
+    "PartInfoType": {
+        "type": "object",
+        "description": "Supplementary XSD-derived reusable type corresponding to a content part.",
+        "properties": {
+            "identifier": {
+                "type": "string",
+                "description": "Identifier for this content part."
+            },
+            "contentType": {
+                "type": "string",
+                "description": "MIME type or other content type designation."
+            },
+            "digestMethod": {
+                "type": "object",
+                "description": "Algorithm used to compute the digest (ds:DigestMethod).",
+                "properties": {
+                    "algorithm": {
+                        "type": "string",
+                        "format": "uri"
+                    }
+                },
+                "required": [
+                    "algorithm"
+                ]
+            },
+            "digestValue": {
+                "type": "string",
+                "contentEncoding": "base64",
+                "description": "Base64-encoded digest value (ds:DigestValue)."
+            }
+        },
+        "required": [
+            "identifier",
+            "contentType"
+        ]
+    },
+    "PartsInfoType": {
+        "type": "object",
+        "description": "Supplementary XSD-derived reusable type corresponding to a collection of content parts.",
+        "properties": {
+            "partInfo": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "$ref": "#/definitions/PartInfoType"
+                },
+                "description": "One or more partInfo elements describing individual content parts."
+            }
+        },
+        "required": [
+            "partInfo"
+        ]
+    },
+    "UserContentInfoType": {
+        "type": "object",
+        "description": "Supplementary XSD-derived reusable type for user content information.",
+        "properties": {
+            "appLayerIdentifier": {
+                "type": "string",
+                "description": "Optional application-layer identifier for the message."
+            },
+            "composingParts": {
+                "type": "integer",
+                "description": "Optional total number of parts composing the message."
+            },
+            "partsInfo": {
+                "$ref": "#/definitions/PartsInfoType",
+                "description": "Container for one or more content parts."
+            }
+        },
+        "required": [
+            "partsInfo"
+        ]
+    },
+    "ConsigmentModeType": {
+        "type": "string",
+        "format": "uri",
+        "description": "Consignment mode value from the XSD model (using the original XSD type name spelling).",
+        "enum": [
+            "http://uri.etsi.org/19522/v1#/consignment/basic",
+            "http://uri.etsi.org/19522/v1#/consignment/consent",
+            "http://uri.etsi.org/19522/v1#/consignment/signed",
+            "http://uri.etsi.org/19522/v1#/consignment/other"
+        ]
+    },
+    "ComponentsType": {
+        "type": "object",
+        "description": "JSON projection of the XSD Components group, with ds:Signature fully replaced by jadesSignature.",
+        "properties": {
+            "eventReasons": {
+                "type": "object",
+                "description": "Container for one or more event reasons.",
+                "properties": {
+                    "eventReason": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "description": "A single reason that caused the ERDS event. code is a URI; details provides optional elaboration.",
+                            "properties": {
+                                "code": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "description": "URI identifying the event reason."
+                                },
+                                "details": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "description": "Optional additional details about the reason."
+                                }
+                            },
+                            "required": [
+                                "code"
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "eventReason"
+                ]
+            },
+            "eventTime": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Date and time of the event."
+            },
+            "evidenceIssuerPolicyId": {
+                "type": "object",
+                "description": "One or more policy identifiers (URIs, or URNs per RFC 3061 for OID-based policies).",
+                "properties": {
+                    "policyId": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "minItems": 1
+                    }
+                },
+                "required": [
+                    "policyId"
+                ]
+            },
+            "evidenceIssuerDetails": {
+                "$ref": "#/definitions/EntityDetailsType",
+                "description": "Details of the entity that issued this evidence."
+            },
+            "senderDetails": {
+                "$ref": "#/definitions/UserDetailsType",
+                "description": "Details of the message sender."
+            },
+            "senderDelegateDetails": {
+                "$ref": "#/definitions/UserDetailsType",
+                "description": "Details of a delegate acting on behalf of the sender."
+            },
+            "recipientDetails": {
+                "type": "array",
+                "description": "One or more recipients of the message.",
+                "items": {
+                    "$ref": "#/definitions/UserDetailsType"
+                },
+                "minItems": 1
+            },
+            "recipientsDelegateDetails": {
+                "type": "array",
+                "description": "Zero or more delegates acting on behalf of recipients.",
+                "items": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/UserDetailsType"
+                        },
+                        {
+                            "type": "object",
+                            "description": "Extends UserDetailsType with the list of recipients for whom this delegate acts.",
+                            "properties": {
+                                "delegatingRecipients": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "integer"
+                                    },
+                                    "description": "Indices (integers) of recipientDetails entries for which this delegate acts. Represented as xs:list of xs:integer in XSD."
+                                }
+                            },
+                            "required": [
+                                "delegatingRecipients"
+                            ]
+                        }
+                    ]
+                }
+            },
+            "submissionTime": {
+                "type": "string",
+                "format": "date-time",
+                "description": "Time at which the message was submitted."
+            },
+            "evidenceRefersToRecipient": {
+                "type": "integer",
+                "description": "1-based index into recipientDetails identifying the specific recipient this evidence pertains to."
+            },
+            "messageIdentifier": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Non-empty string identifying the message."
+            },
+            "userContentInfo": {
+                "type": "object",
+                "description": "Metadata about the user message content.",
+                "properties": {
+                    "appLayerIdentifier": {
+                        "type": "string",
+                        "description": "Optional application-layer identifier for the message."
+                    },
+                    "composingParts": {
+                        "type": "integer",
+                        "description": "Optional total number of parts composing the message."
+                    },
+                    "partsInfo": {
+                        "type": "array",
+                        "description": "One or more partInfo elements describing individual content parts.",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "description": "Metadata for a single content part, including an optional digest.",
+                            "properties": {
+                                "identifier": {
+                                    "type": "string",
+                                    "description": "Identifier for this content part."
+                                },
+                                "contentType": {
+                                    "type": "string",
+                                    "description": "MIME type or other content type designation."
+                                },
+                                "digestMethod": {
+                                    "type": "object",
+                                    "description": "Algorithm used to compute the digest (ds:DigestMethod).",
+                                    "properties": {
+                                        "algorithm": {
+                                            "type": "string",
+                                            "format": "uri"
+                                        }
+                                    },
+                                    "required": [
+                                        "algorithm"
+                                    ]
+                                },
+                                "digestValue": {
+                                    "type": "string",
+                                    "contentEncoding": "base64",
+                                    "description": "Base64-encoded digest value (ds:DigestValue)."
+                                }
+                            },
+                            "required": [
+                                "identifier",
+                                "contentType"
+                            ]
+                        }
+                    }
+                },
+                "required": [
+                    "partsInfo"
+                ],
+                "examples": [
+                    {
+                        "appLayerIdentifier": "contract",
+                        "composingParts": 1,
+                        "partsInfo": [
+                            {
+                                "identifier": "contract.pdf",
+                                "contentType": "application/pdf",
+                                "digestMethod": {
+                                    "algorithm": "http://www.w3.org/2001/04/xmlenc#sha256"
+                                },
+                                "digestValue": "ZXhhbXBsZWRpZ2VzdHZhbHVlZm9yY29udHJhY3RwZGY="
+                            }
+                        ]
+                    }
+                ]
+            },
+            "externalErdsDetails": {
+                "$ref": "#/definitions/EntityDetailsType",
+                "description": "Details of an external ERDS involved in the delivery."
+            },
+            "forwardedToExternalSystem": {
+                "type": "string",
+                "description": "Identifier of an external system to which the message was forwarded."
+            },
+            "transactionLogInformation": {
+                "type": "object",
+                "description": "References to one or more external transaction logs.",
+                "properties": {
+                    "transactionLog": {
+                        "type": "array",
+                        "items": {},
+                        "minItems": 1,
+                        "description": "One or more transaction log entries (open content)."
+                    }
+                },
+                "required": [
+                    "transactionLog"
+                ]
+            },
+            "extensions": {
+                "type": "array",
+                "description": "One or more extension elements.",
+                "minItems": 1,
+                "items": {
+                    "allOf": [
+                        {},
+                        {
+                            "type": "object",
+                            "description": "Extension element with an optional criticality flag (isCritical XML attribute).",
+                            "properties": {
+                                "isCritical": {
+                                    "type": "boolean",
+                                    "description": "When true, processors that do not understand this extension MUST reject processing."
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            "jadesSignature": {
+                "$ref": "#/definitions/JAdESSignature",
+                "description": "Optional JAdES signature replacing the XML ds:Signature element."
+            }
+        },
+        "required": [
+            "eventTime",
+            "evidenceIssuerDetails",
+            "senderDetails",
+            "recipientDetails"
+        ]
+    },
+    "Evidence": {
+        "allOf": [
+            {
+                "type": "object",
+                "description": "Bundled root schema for Evidence, corresponding to the global Evidence element."
+            },
+            {
+                "$ref": "#"
+            }
+        ]
+    },
+    "RelayMetadata": {
+        "type": "object",
+        "description": "Bundled root schema for RelayMetadata, corresponding to the global RelayMetadata element.",
+        "allOf": [
+            {
+                "$ref": "#/definitions/RelayMetadataType"
+            }
+        ]
+    },
+    "ERDSMetadata": {
+        "type": "object",
+        "description": "Bundled root schema for ERDSMetadata, corresponding to the global ERDSMetadata element.",
+        "allOf": [
+            {
+                "$ref": "#/definitions/ERDSMetadataType"
+            }
+        ]
     }
   }
 }

--- a/docs/qerds/data-schemas/erds-evidence.json
+++ b/docs/qerds/data-schemas/erds-evidence.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://uri.etsi.org/19522/v1#/Evidence",
+  "$id": "http://uri.etsi.org/19522/v1/json",
   "title": "ETSI EN 319 522-3 V1.2.1 Evidence",
   "description": "JSON Schema for Electronic Registered Delivery Service (ERDS) Evidence, structurally equivalent to the EvidenceType XML Schema in ETSI EN 319 522-3 V1.2.1 (namespace http://uri.etsi.org/19522/v1#). XML attributes are represented as properties; repeating elements are represented as arrays.",
   "type": "object",
@@ -9,83 +9,78 @@
       "type": "string",
       "description": "Schema version (required XML attribute)."
     },
-    "id": {
+    "Id": {
       "type": "string",
       "description": "Optional XML attribute Id (xs:ID)."
     },
-    "evidenceIdentifier": {
+    "EvidenceIdentifier": {
       "type": "string",
       "description": "String identifier for this evidence instance."
     },
-    "erdsEventId": {
-      "type": "string",
-      "format": "uri",
-      "description": "URI identifying the ERDS event that triggered production of this evidence (Table 2)."
-    },
-    "eventReasons": {
+    "EventReasons": {
       "type": "object",
       "description": "Container for one or more event reasons.",
       "properties": {
-        "eventReason": {
+        "EventReason": {
           "type": "array",
           "minItems": 1,
           "items": {
             "type": "object",
             "description": "A single reason that caused the ERDS event. code is a URI; details provides optional elaboration.",
             "properties": {
-              "code": {
+              "Code": {
                 "type": "string",
                 "format": "uri",
                 "description": "URI identifying the event reason."
               },
-              "details": {
+              "Details": {
                 "type": "array",
                 "items": { "type": "string" },
                 "description": "Optional additional details about the reason."
               }
             },
-            "required": ["code"]
+            "required": ["Code"]
           }
         }
       },
-      "required": ["eventReason"]
+      "required": ["EventReason"]
     },
-    "eventTime": {
+    "EventTime": {
       "type": "string",
       "format": "date-time",
       "description": "Date and time of the event."
     },
-    "evidenceIssuerPolicyId": {
+    "EvidenceIssuerPolicyID": {
       "type": "object",
       "description": "One or more policy identifiers (URIs, or URNs per RFC 3061 for OID-based policies).",
       "properties": {
-        "policyId": {
+        "PolicyID": {
           "type": "array",
           "items": { "type": "string", "format": "uri" },
           "minItems": 1
         }
       },
-      "required": ["policyId"]
+      "required": ["PolicyID"]
     },
-    "evidenceIssuerDetails": {
+    "EvidenceIssuerDetails": {
       "$ref": "#/definitions/EntityDetailsType",
       "description": "Details of the entity that issued this evidence."
     },
-    "senderDetails": {
+    "SenderDetails": {
       "$ref": "#/definitions/UserDetailsType",
       "description": "Details of the message sender."
     },
-    "senderDelegateDetails": {
+    "SenderDelegateDetails": {
       "$ref": "#/definitions/UserDetailsType",
       "description": "Details of a delegate acting on behalf of the sender."
     },
-    "recipientDetails": {
+    "RecipientDetails": {
       "type": "array",
       "description": "One or more recipients of the message.",
       "items": { "$ref": "#/definitions/UserDetailsType" },
       "minItems": 1
     },
-    "recipientsDelegateDetails": {
+    "RecipientsDelegateDetails": {
       "type": "array",
       "description": "Zero or more delegates acting on behalf of recipients.",
       "items": {
@@ -95,123 +90,77 @@
             "type": "object",
             "description": "Extends UserDetailsType with the list of recipients for whom this delegate acts.",
             "properties": {
-              "delegatingRecipients": {
+              "DelegatingRecipients": {
                 "type": "array",
                 "items": { "type": "integer" },
                 "description": "Indices (integers) of recipientDetails entries for which this delegate acts. Represented as xs:list of xs:integer in XSD."
               }
-            },
-            "required": ["delegatingRecipients"]
+            }
           }
         ]
       }
     },
-    "submissionTime": {
+    "SubmissionTime": {
       "type": "string",
       "format": "date-time",
       "description": "Time at which the message was submitted."
     },
-    "evidenceRefersToRecipient": {
+    "EvidenceRefersToRecipient": {
       "type": "integer",
       "description": "1-based index into recipientDetails identifying the specific recipient this evidence pertains to."
     },
-    "messageIdentifier": {
+    "MessageIdentifier": {
       "type": "string",
       "minLength": 1,
       "description": "Non-empty string identifying the message."
     },
-    "userContentInfo": {
-      "type": "object",
+    "UserContentInfo": {
+      "$ref": "#/definitions/UserContentInfoType",
       "description": "Metadata about the user message content.",
-      "properties": {
-        "appLayerIdentifier": {
-          "type": "string",
-          "description": "Optional application-layer identifier for the message."
-        },
-        "composingParts": {
-          "type": "integer",
-          "description": "Optional total number of parts composing the message."
-        },
-        "partsInfo": {
-          "type": "array",
-          "description": "One or more partInfo elements describing individual content parts.",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "description": "Metadata for a single content part, including an optional digest.",
-            "properties": {
-              "identifier": {
-                "type": "string",
-                "description": "Identifier for this content part."
-              },
-              "contentType": {
-                "type": "string",
-                "description": "MIME type or other content type designation."
-              },
-              "digestMethod": {
-                "type": "object",
-                "description": "Algorithm used to compute the digest (ds:DigestMethod).",
-                "properties": {
-                  "algorithm": { "type": "string", "format": "uri" }
-                },
-                "required": ["algorithm"]
-              },
-              "digestValue": {
-                "type": "string",
-                "contentEncoding": "base64",
-                "description": "Base64-encoded digest value (ds:DigestValue)."
-              }
-            },
-            "required": ["identifier", "contentType"]
-          }
-        }
-      },
-      "required": ["partsInfo"],
       "examples": [
         {
-          "appLayerIdentifier": "contract",
-          "composingParts": 1,
-          "partsInfo": [
+          "AppLayerIdentifier": "contract",
+          "ComposingParts": 1,
+          "PartsInfo": [
             {
-              "identifier": "contract.pdf",
-              "contentType": "application/pdf",
-              "digestMethod": {
-                "algorithm": "http://www.w3.org/2001/04/xmlenc#sha256"
+              "Identifier": "contract.pdf",
+              "ContentType": "application/pdf",
+              "DigestMethod": {
+                "Algorithm": "http://www.w3.org/2001/04/xmlenc#sha256"
               },
-              "digestValue": "ZXhhbXBsZWRpZ2VzdHZhbHVlZm9yY29udHJhY3RwZGY="
+              "DigestValue": "ZXhhbXBsZWRpZ2VzdHZhbHVlZm9yY29udHJhY3RwZGY="
             }
           ]
         }
       ]
     },
-    "externalErdsDetails": {
+    "ExternalERDSDetails": {
       "$ref": "#/definitions/EntityDetailsType",
       "description": "Details of an external ERDS involved in the delivery."
     },
-    "forwardedToExternalSystem": {
+    "ForwardedToExternalSystem": {
       "type": "string",
       "description": "Identifier of an external system to which the message was forwarded."
     },
-    "transactionLogInformation": {
+    "TransactionLogInformation": {
       "type": "object",
       "description": "References to one or more external transaction logs.",
       "properties": {
-        "transactionLog": {
+        "TransactionLog": {
           "type": "array",
           "items": {},
           "minItems": 1,
           "description": "One or more transaction log entries (open content)."
         }
       },
-      "required": ["transactionLog"]
+      "required": ["TransactionLog"]
     },
-    "extensions": {
+    "Extensions": {
       "type": "array",
       "description": "One or more extension elements.",
       "minItems": 1,
       "items": {
         "allOf": [
-          {},
           {
             "type": "object",
             "description": "Extension element with an optional criticality flag (isCritical XML attribute).",
@@ -232,20 +181,20 @@
   },
   "required": [
     "version",
-    "evidenceIdentifier",
-    "erdsEventId",
-    "eventTime",
-    "evidenceIssuerDetails",
-    "senderDetails",
-    "recipientDetails"
+    "EvidenceIdentifier",
+    "ERDSEventId",
+    "EventTime",
+    "EvidenceIssuerDetails",
+    "SenderDetails",
+    "RecipientDetails"
   ],
   "definitions": {
     "EntityDetailsType": {
       "type": "object",
       "description": "Identity and optional certificate details for an entity (issuer or external ERDS).",
       "properties": {
-        "identity": { "$ref": "#/definitions/IdentityAttributesType" },
-        "certificateDetails": {
+        "Identity": { "$ref": "#/definitions/IdentityAttributesType" },
+        "CertificateDetails": {
           "type": "array",
           "description": "One to three certificate representations, each being an X.509 certificate, a certificate ID, or a certificate ID and signature details (xs:choice maxOccurs='3').",
           "minItems": 1,
@@ -256,47 +205,47 @@
                 "type": "object",
                 "description": "DER-encoded X.509 certificate in Base64.",
                 "properties": {
-                  "x509Certificate": {
+                  "X509Certificate": {
                     "type": "string",
                     "contentEncoding": "base64"
                   }
                 },
-                "required": ["x509Certificate"],
+                "required": ["X509Certificate"],
                 "additionalProperties": false
               },
               {
                 "type": "object",
                 "description": "Certificate identified by digest and optional issuer/serial.",
                 "properties": {
-                  "certId": { "$ref": "#/definitions/CertIDTypeV2" }
+                  "CertID": { "$ref": "#/definitions/CertIDTypeV2" }
                 },
-                "required": ["certId"],
+                "required": ["CertID"],
                 "additionalProperties": false
               },
               {
                 "type": "object",
                 "description": "Certificate identified by digest and accompanied by signature details.",
                 "properties": {
-                  "certIdAndSignature": { "$ref": "#/definitions/CertIDAndSignatureType" }
+                  "CertIDAndSignature": { "$ref": "#/definitions/CertIDAndSignatureType" }
                 },
-                "required": ["certIdAndSignature"],
+                "required": ["CertIDAndSignature"],
                 "additionalProperties": false
               }
             ]
           }
         },
-        "any": {
+        "Any": {
           "description": "Extension point for additional entity data."
         }
       },
-      "required": ["identity"]
+      "required": ["Identity"]
     },
 
     "IdentityAttributesType": {
       "type": "object",
       "description": "One or more SAML Attributes describing the entity's identity.",
       "properties": {
-        "attribute": {
+        "Attribute": {
           "type": "array",
           "description": "SAML 2.0 Attributes (saml:Attribute).",
           "minItems": 1,
@@ -304,132 +253,119 @@
             "type": "object",
             "description": "SAML 2.0 saml:Attribute element.",
             "properties": {
-              "name": {
+              "Name": {
                 "type": "string",
                 "description": "Attribute name (required)."
               },
-              "nameFormat": {
+              "NameFormat": {
                 "type": "string",
                 "format": "uri",
                 "description": "URI identifying the name format."
               },
-              "friendlyName": {
+              "FriendlyName": {
                 "type": "string",
                 "description": "Human-readable name for the attribute."
               },
-              "attributeValue": {
+              "AttributeValue": {
                 "type": "array",
                 "items": {},
                 "description": "Zero or more attribute values (saml:AttributeValue); each value may be any type."
               }
             },
-            "required": ["name"]
+            "required": ["Name"]
           }
         }
       },
-      "required": ["attribute"]
+      "required": ["Attribute"]
     },
 
     "CertIDTypeV2": {
       "type": "object",
       "description": "Certificate identifier comprising a digest and an optional issuer/serial (V2 variant per RFC 5652).",
       "properties": {
-        "uri": {
+        "URI": {
           "type": "string",
           "format": "uri",
           "description": "Optional URI locating the certificate."
         },
-        "certDigest": {
+        "CertDigest": {
           "type": "object",
           "description": "Digest of the certificate (ds:DigestMethod + ds:DigestValue).",
           "properties": {
-            "digestMethod": {
+            "DigestMethod": {
               "type": "object",
               "description": "XML digital signature DigestMethod: identifies the digest algorithm by URI.",
               "properties": {
-                "algorithm": { "type": "string", "format": "uri" }
+                "Algorithm": { "type": "string", "format": "uri" }
               },
-              "required": ["algorithm"]
+              "required": ["Algorithm"]
             },
-            "digestValue": { "type": "string", "contentEncoding": "base64" }
+            "DigestValue": { "type": "string", "contentEncoding": "base64" }
           },
-          "required": ["digestMethod", "digestValue"]
+          "required": ["DigestMethod", "DigestValue"]
         },
-        "issuerSerialV2": {
+        "IssuerSerialV2": {
           "type": "string",
           "contentEncoding": "base64",
           "description": "DER-encoded IssuerSerial (V2) identifying the certificate issuer and serial number."
         }
       },
-      "required": ["certDigest"]
+      "required": ["CertDigest"]
     },
 
     "UserDetailsType": {
       "type": "object",
       "description": "Identity, identifier, and assurance details for a user (sender, recipient, or delegate).",
       "properties": {
-        "identity": { "$ref": "#/definitions/IdentityAttributesType" },
-        "identifier": {
-          "type": "object",
-          "description": "A non-empty string identifier within a named scheme (xs:simpleContent extension).",
-          "properties": {
-            "value": {
-              "type": "string",
-              "minLength": 1,
-              "description": "The identifier value."
-            },
-            "identifierSchemeName": {
-              "type": "string",
-              "minLength": 1,
-              "description": "Name of the identification scheme (required XML attribute)."
-            }
-          },
-          "required": ["value", "identifierSchemeName"]
+        "Identity": { "$ref": "#/definitions/IdentityAttributesType" },
+        "Identifier": {
+          "$ref": "#/definitions/EntityIdentifierType",
+          "description": "Non-empty string identifier within a named scheme."
         },
-        "assuranceLevelsDetails": {
+        "AssuranceLevelsDetails": {
           "description": "Assurance level information expressed as one of two alternative structures (xs:choice of two sequences).",
           "oneOf": [
             {
               "type": "object",
               "description": "Option 1: a global assurance level together with authentication details.",
               "properties": {
-                "globalAssuranceLevel": {
+                "GlobalAssuranceLevel": {
                   "$ref": "#/definitions/AssuranceLevelDetailsType"
                 },
-                "authenticationDetails": {
+                "AuthenticationDetails": {
                   "$ref": "#/definitions/AuthenticationDetailsType"
                 }
               },
-              "required": ["globalAssuranceLevel", "authenticationDetails"],
+              "required": ["GlobalAssuranceLevel", "AuthenticationDetails"],
               "additionalProperties": false
             },
             {
               "type": "object",
               "description": "Option 2: per-factor assurance levels (authentication, identity proof, optional federation).",
               "properties": {
-                "authenticationDetsAndAssuranceLevel": {
+                "AuthenticationDetsAndAssuranceLevel": {
                   "type": "object",
                   "description": "An assurance level paired with optional authentication details.",
                   "properties": {
-                    "assuranceLevel": {
+                    "AssuranceLevel": {
                       "$ref": "#/definitions/AssuranceLevelDetailsType"
                     },
-                    "authenticationDetails": {
+                    "AuthenticationDetails": {
                       "$ref": "#/definitions/AuthenticationDetailsType"
                     }
                   },
-                  "required": ["assuranceLevel"]
+                  "required": ["AssuranceLevel"]
                 },
-                "identityProofAssuranceLevel": {
+                "IdentityProofAssuranceLevel": {
                   "$ref": "#/definitions/AssuranceLevelDetailsType"
                 },
-                "federationAssuranceLevel": {
+                "FederationAssuranceLevel": {
                   "$ref": "#/definitions/AssuranceLevelDetailsType"
                 }
               },
               "required": [
-                "authenticationDetsAndAssuranceLevel",
-                "identityProofAssuranceLevel"
+                "AuthenticationDetsAndAssuranceLevel",
+                "IdentityProofAssuranceLevel"
               ],
               "additionalProperties": false
             }
@@ -442,21 +378,21 @@
       "type": "object",
       "description": "Details about a single assurance level, including an optional policy reference.",
       "properties": {
-        "assuranceLevel": {
+        "AssuranceLevel": {
           "type": "string",
           "format": "uri",
           "description": "URI identifying the assurance level."
         },
-        "policyId": {
+        "PolicyID": {
           "type": "string",
           "format": "uri",
           "description": "Optional URI identifying an applicable policy."
         },
-        "policyIdDetails": {
+        "PolicyIDDetails": {
           "type": "string",
           "description": "Optional textual details about the policy."
         },
-        "policyIdDetailsResources": {
+        "PolicyIDDetailsResources": {
           "type": "array",
           "description": "Optional multilingual URIs for policy detail resources.",
           "minItems": 1,
@@ -474,7 +410,7 @@
           }
         }
       },
-      "required": ["assuranceLevel"]
+      "required": ["AssuranceLevel"]
     },
 
     "AuthenticationDetailsType": {
@@ -484,31 +420,31 @@
           "type": "object",
           "description": "SAML 2.0 Assertion.",
           "properties": {
-            "assertion": {
+            "Assertion": {
               "type": "object",
               "description": "SAML 2.0 saml:Assertion element (externally defined)."
             }
           },
-          "required": ["assertion"],
+          "required": ["Assertion"],
           "additionalProperties": false
         },
         {
           "type": "object",
           "description": "OAuth2 token (any structure).",
           "properties": {
-            "oAuth2": {}
+            "OAuth2": {}
           },
-          "required": ["oAuth2"],
+          "required": ["OAuth2"],
           "additionalProperties": false
         },
         {
           "type": "object",
           "description": "Explicit authentication time and method URI.",
           "properties": {
-            "authenticationTime": { "type": "string", "format": "date-time" },
-            "authenticationMethod": { "type": "string", "format": "uri" }
+            "AuthenticationTime": { "type": "string", "format": "date-time" },
+            "AuthenticationMethod": { "type": "string", "format": "uri" }
           },
-          "required": ["authenticationTime", "authenticationMethod"],
+          "required": ["AuthenticationTime", "AuthenticationMethod"],
           "additionalProperties": false
         },
         {
@@ -523,39 +459,57 @@
       ]
     },
     "CertSignatureDetailsType": {
-        "type": "object",
-        "description": "Signature details associated with a certificate reference.",
-        "properties": {
-            "signatureAlgorithm": {
-                "type": "string",
-                "format": "uri",
-                "description": "URI identifying the signature algorithm."
-            },
-            "signatureValue": {
-                "type": "string",
-                "contentEncoding": "base64",
-                "description": "Base64-encoded signature value."
-            }
+      "type": "object",
+      "description": "Signature details associated with a certificate reference.",
+      "properties": {
+        "SignatureMethod": {
+          "$ref": "#/definitions/SignatureMethodType",
+          "description": "Signature algorithm identifier (ds:SignatureMethod)." 
         },
-        "required": [
-            "signatureAlgorithm",
-            "signatureValue"
-        ]
+        "SignatureValue": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "description": "Base64-encoded signature value."
+        }
+      },
+      "required": [
+        "SignatureMethod",
+        "SignatureValue"
+      ]
+    },
+    "SignatureMethodType": {
+      "type": "object",
+      "description": "JSON projection of ds:SignatureMethod from XML Digital Signature (http://www.w3.org/2000/09/xmldsig#). Contains a mandatory Algorithm URI attribute and optional additional content.",
+      "properties": {
+        "Algorithm": {
+          "type": "string",
+          "format": "uri",
+          "description": "URI identifying the signature algorithm (required ds:SignatureMethod/@Algorithm attribute)."
+        },
+        "HMACOutputLength": {
+          "type": "integer",
+          "description": "Optional HMAC output length in bits (ds:HMACOutputLength)."
+        },
+        "Any": {
+          "description": "Optional extension content from other namespaces (xs:any namespace='##other' processContents='lax')."
+        }
+      },
+      "required": ["Algorithm"]
     },
     "CertIDAndSignatureType": {
         "type": "object",
         "description": "Certificate identifier together with signature details.",
         "properties": {
-            "certId": {
+            "CertID": {
                 "$ref": "#/definitions/CertIDTypeV2"
             },
-            "certSignatureDetails": {
+            "CertSignatureDetails": {
                 "$ref": "#/definitions/CertSignatureDetailsType"
             }
         },
         "required": [
-            "certId",
-            "certSignatureDetails"
+            "CertID",
+            "CertSignatureDetails"
         ]
     },
     "Base64UrlString": {
@@ -787,12 +741,10 @@
         "description": "Non-empty string with required type attribute.",
         "properties": {
             "value": {
-                "type": "string",
-                "minLength": 1
+                "$ref": "#/definitions/NonEmptyStringType"
             },
             "type": {
-                "type": "string",
-                "minLength": 1
+                "$ref": "#/definitions/NonEmptyStringType"
             }
         },
         "required": [
@@ -809,28 +761,28 @@
         "type": "object",
         "description": "Digest composed of ds:DigestMethod and ds:DigestValue.",
         "properties": {
-            "digestMethod": {
+            "DigestMethod": {
                 "type": "object",
                 "description": "XML digital signature DigestMethod: identifies the digest algorithm by URI.",
                 "properties": {
-                    "algorithm": {
+                    "Algorithm": {
                         "type": "string",
                         "format": "uri"
                     }
                 },
                 "required": [
-                    "algorithm"
+                    "Algorithm"
                 ]
             },
-            "digestValue": {
+            "DigestValue": {
                 "type": "string",
                 "contentEncoding": "base64",
                 "description": "Base64-encoded digest value (ds:DigestValue)."
             }
         },
         "required": [
-            "digestMethod",
-            "digestValue"
+            "DigestMethod",
+            "DigestValue"
         ]
     },
     "ConsignmentModeType": {
@@ -864,58 +816,58 @@
                 "minLength": 1,
                 "description": "Schema version (required XML attribute)."
             },
-            "messageIdentifier": {
+            "MessageIdentifier": {
                 "$ref": "#/definitions/MessageIdentifierType",
                 "description": "Non-empty string identifying the message."
             },
-            "erdMessageType": {
+            "ERDMessageType": {
                 "$ref": "#/definitions/ERDSMessageTypeType",
                 "description": "Type of ERDS relay message."
             },
-            "inReplyTo": {
+            "InReplyTo": {
                 "$ref": "#/definitions/MessageIdentifierType",
                 "description": "Optional message identifier to which this relay metadata refers."
             },
-            "relayTime": {
+            "RelayTime": {
                 "type": "string",
                 "format": "date-time",
                 "description": "Time at which the relay occurred."
             },
-            "expirationTime": {
+            "ExpirationTime": {
                 "type": "string",
                 "format": "date-time",
                 "description": "Optional expiration time."
             },
-            "scheduledDeliveryTime": {
+            "ScheduledDeliveryTime": {
                 "type": "string",
                 "format": "date-time",
                 "description": "Optional scheduled delivery time."
             },
-            "senderId": {
-                "$ref": "#/definitions/AttributedNonEmptyStringType",
+            "SenderId": {
+                "$ref": "#/definitions/EntityIdentifierType",
                 "description": "Identifier of the sender entity."
             },
-            "replyTo": {
-                "$ref": "#/definitions/AttributedNonEmptyStringType",
+            "ReplyTo": {
+                "$ref": "#/definitions/EntityIdentifierType",
                 "description": "Optional reply-to entity identifier."
             },
-            "recipientId": {
-                "$ref": "#/definitions/AttributedNonEmptyStringType",
+            "RecipientId": {
+                "$ref": "#/definitions/EntityIdentifierType",
                 "description": "Identifier of the recipient entity."
             },
-            "userContentInfo": {
+            "UserContentInfo": {
                 "$ref": "#/definitions/UserContentInfoType",
                 "description": "Metadata about the user message content."
             },
-            "requiredAssuranceLevel": {
+            "RequiredAssuranceLevel": {
                 "$ref": "#/definitions/AssuranceLevelDetailsType",
                 "description": "Optional required assurance level."
             },
-            "applicablePolicy": {
+            "ApplicablePolicy": {
                 "type": "object",
                 "description": "One or more policy identifiers (URIs, or URNs per RFC 3061 for OID-based policies).",
                 "properties": {
-                    "policyId": {
+                    "PolicyID": {
                         "type": "array",
                         "items": {
                             "type": "string",
@@ -925,15 +877,15 @@
                     }
                 },
                 "required": [
-                    "policyId"
+                    "PolicyID"
                 ]
             },
-            "requestedConsignmentMode": {
-                "$ref": "#/definitions/ConsigmentModeType",
+            "RequestedConsignmentMode": {
+                "$ref": "#/definitions/ConsignmentModeType",
                 "description": "Requested consignment mode."
             },
-            "extensions": {
-                "$ref": "#/definitions/ExtensionsType",
+            "Extensions": {
+                "$ref": "#/definitions/ExtensionsListType",
                 "description": "Optional extensions."
             },
             "jadesSignature": {
@@ -943,12 +895,27 @@
         },
         "required": [
             "version",
-            "messageIdentifier",
-            "erdMessageType",
-            "senderId",
-            "recipientId",
-            "userContentInfo"
+            "MessageIdentifier",
+            "ERDMessageType",
+            "SenderId",
+            "RecipientId",
+            "UserContentInfo"
         ]
+    },
+    "EntityIdentifierType": {
+      "type": "object",
+      "description": "Non-empty string identifier within a named scheme — xs:simpleContent extension of NonEmptyStringType with required IdentifierSchemeName attribute",
+      "properties": {
+        "value": {
+          "$ref": "#/definitions/NonEmptyStringType",
+          "description": "Text content of the element — the identifier value"
+        },
+        "IdentifierSchemeName": {
+          "$ref": "#/definitions/NonEmptyStringType",
+          "description": "Required attribute identifying the naming scheme"
+        }
+      },
+      "required": ["value", "IdentifierSchemeName"]
     },
     "ERDSMetadataType": {
         "type": "object",
@@ -959,59 +926,59 @@
                 "minLength": 1,
                 "description": "Schema version (required XML attribute)."
             },
-            "erdsId": {
-                "$ref": "#/definitions/AttributedNonEmptyStringType",
+            "ERDSId": {
+                "$ref": "#/definitions/EntityIdentifierType",
                 "description": "Identifier of the ERDS entity."
             },
-            "erdsDomain": {
+            "ERDSDomain": {
                 "type": "string",
                 "description": "ERDS domain."
             },
-            "erdsGoverningBody": {
+            "ERDSGoverningBody": {
                 "type": "string",
                 "description": "ERDS governing body."
             },
-            "erdsProfileSupported": {
+            "ERDSProfileSupported": {
                 "type": "string",
                 "format": "uri",
                 "description": "Supported ERDS profile URI."
             },
-            "erdsMetadataRepository": {
+            "ERDSMetadataRepository": {
                 "type": "string",
                 "format": "uri",
                 "description": "Optional metadata repository URI."
             },
-            "erdsEuQualifiedIndicator": {
+            "ERDSEUQualifiedIndicator": {
                 "type": "boolean",
                 "description": "Optional EU qualified indicator."
             },
-            "erdsTlsLocation": {
+            "ERDSTLSLocation": {
                 "type": "string",
                 "format": "uri",
                 "description": "Optional TLS location URI."
             },
-            "erdsRootCaCertLocation": {
+            "ERDSRootCACertLocation": {
                 "type": "string",
                 "format": "uri",
                 "description": "Optional root CA certificate location URI."
             },
-            "erdsExpiryDateAndTimeSupport": {
+            "ERDSExpiryDateAndTimeSupport": {
                 "type": "boolean",
                 "description": "Whether expiry date and time is supported."
             },
-            "erdsScheduledDeliverySupport": {
+            "ERDSScheduledDeliverySupport": {
                 "type": "boolean",
                 "description": "Whether scheduled delivery is supported."
             },
-            "erdsAssuranceLevelsSupported": {
+            "ERDSAssuranceLevelsSupported": {
                 "$ref": "#/definitions/AssuranceLevelDetailsType",
                 "description": "Optional supported assurance levels."
             },
-            "erdsPolicySupport": {
+            "ERDSPolicySupport": {
                 "type": "object",
                 "description": "One or more policy identifiers (URIs, or URNs per RFC 3061 for OID-based policies).",
                 "properties": {
-                    "policyId": {
+                    "PolicyID": {
                         "type": "array",
                         "items": {
                             "type": "string",
@@ -1021,28 +988,28 @@
                     }
                 },
                 "required": [
-                    "policyId"
+                    "PolicyID"
                 ]
             },
-            "erdsSupportedConsignmentModes": {
-                "$ref": "#/definitions/ConsigmentModeType",
+            "ERDSSupportedConsignmentModes": {
+                "$ref": "#/definitions/ConsignmentModeType",
                 "description": "Optional supported consignment mode."
             }
         },
         "required": [
             "version",
-            "erdsId",
-            "erdsDomain",
-            "erdsGoverningBody",
-            "erdsProfileSupported",
-            "erdsExpiryDateAndTimeSupport",
-            "erdsScheduledDeliverySupport"
+            "ERDSId",
+            "ERDSDomain",
+            "ERDSGoverningBody",
+            "ERDSProfileSupported",
+            "ERDSExpiryDateAndTimeSupport",
+            "ERDSScheduledDeliverySupport"
         ]
     },
-    "ExtensionsType": {
+    "ExtensionsListType": {
         "type": "object",
         "properties": {
-            "extension": {
+            "Extension": {
                 "type": "array",
                 "minItems": 1,
                 "items": {
@@ -1051,9 +1018,9 @@
             }
         },
         "required": [
-            "extension"
+            "Extension"
         ],
-        "description": "Container corresponding to the XSD ExtensionsType."
+        "description": "Container corresponding to the XSD ExtensionsListType."
     },
     "ExtensionType": {
         "allOf": [
@@ -1095,7 +1062,7 @@
         "type": "object",
         "description": "Container for one or more multilingual URIs.",
         "properties": {
-            "uri": {
+            "URI": {
                 "type": "array",
                 "minItems": 1,
                 "items": {
@@ -1104,50 +1071,50 @@
             }
         },
         "required": [
-            "uri"
+            "URI"
         ]
     },
     "PartInfoType": {
         "type": "object",
         "description": "Supplementary XSD-derived reusable type corresponding to a content part.",
         "properties": {
-            "identifier": {
+            "Identifier": {
                 "type": "string",
                 "description": "Identifier for this content part."
             },
-            "contentType": {
+            "ContentType": {
                 "type": "string",
                 "description": "MIME type or other content type designation."
             },
-            "digestMethod": {
+            "DigestMethod": {
                 "type": "object",
                 "description": "Algorithm used to compute the digest (ds:DigestMethod).",
                 "properties": {
-                    "algorithm": {
+                    "Algorithm": {
                         "type": "string",
                         "format": "uri"
                     }
                 },
                 "required": [
-                    "algorithm"
+                    "Algorithm"
                 ]
             },
-            "digestValue": {
+            "DigestValue": {
                 "type": "string",
                 "contentEncoding": "base64",
                 "description": "Base64-encoded digest value (ds:DigestValue)."
             }
         },
         "required": [
-            "identifier",
-            "contentType"
+            "Identifier",
+            "ContentType"
         ]
     },
     "PartsInfoType": {
         "type": "object",
         "description": "Supplementary XSD-derived reusable type corresponding to a collection of content parts.",
         "properties": {
-            "partInfo": {
+            "PartInfo": {
                 "type": "array",
                 "minItems": 1,
                 "items": {
@@ -1157,62 +1124,51 @@
             }
         },
         "required": [
-            "partInfo"
+            "PartInfo"
         ]
     },
     "UserContentInfoType": {
         "type": "object",
         "description": "Supplementary XSD-derived reusable type for user content information.",
         "properties": {
-            "appLayerIdentifier": {
+            "AppLayerIdentifier": {
                 "type": "string",
                 "description": "Optional application-layer identifier for the message."
             },
-            "composingParts": {
+            "ComposingParts": {
                 "type": "integer",
                 "description": "Optional total number of parts composing the message."
             },
-            "partsInfo": {
+            "PartsInfo": {
                 "$ref": "#/definitions/PartsInfoType",
                 "description": "Container for one or more content parts."
             }
         },
         "required": [
-            "partsInfo"
+            "PartsInfo"
         ]
     },
-    "ConsigmentModeType": {
-        "type": "string",
-        "format": "uri",
-        "description": "Consignment mode value from the XSD model (using the original XSD type name spelling).",
-        "enum": [
-            "http://uri.etsi.org/19522/v1#/consignment/basic",
-            "http://uri.etsi.org/19522/v1#/consignment/consent",
-            "http://uri.etsi.org/19522/v1#/consignment/signed",
-            "http://uri.etsi.org/19522/v1#/consignment/other"
-        ]
-    },
-    "ComponentsType": {
+    "Components": {
         "type": "object",
         "description": "JSON projection of the XSD Components group, with ds:Signature fully replaced by jadesSignature.",
         "properties": {
-            "eventReasons": {
+            "EventReasons": {
                 "type": "object",
                 "description": "Container for one or more event reasons.",
                 "properties": {
-                    "eventReason": {
+                    "EventReason": {
                         "type": "array",
                         "minItems": 1,
                         "items": {
                             "type": "object",
                             "description": "A single reason that caused the ERDS event. code is a URI; details provides optional elaboration.",
                             "properties": {
-                                "code": {
+                                "Code": {
                                     "type": "string",
                                     "format": "uri",
                                     "description": "URI identifying the event reason."
                                 },
-                                "details": {
+                                "Details": {
                                     "type": "array",
                                     "items": {
                                         "type": "string"
@@ -1221,25 +1177,25 @@
                                 }
                             },
                             "required": [
-                                "code"
+                                "Code"
                             ]
                         }
                     }
                 },
                 "required": [
-                    "eventReason"
+                    "EventReason"
                 ]
             },
-            "eventTime": {
+            "EventTime": {
                 "type": "string",
                 "format": "date-time",
                 "description": "Date and time of the event."
             },
-            "evidenceIssuerPolicyId": {
+            "EvidenceIssuerPolicyID": {
                 "type": "object",
                 "description": "One or more policy identifiers (URIs, or URNs per RFC 3061 for OID-based policies).",
                 "properties": {
-                    "policyId": {
+                    "PolicyID": {
                         "type": "array",
                         "items": {
                             "type": "string",
@@ -1249,22 +1205,22 @@
                     }
                 },
                 "required": [
-                    "policyId"
+                    "PolicyID"
                 ]
             },
-            "evidenceIssuerDetails": {
+            "EvidenceIssuerDetails": {
                 "$ref": "#/definitions/EntityDetailsType",
                 "description": "Details of the entity that issued this evidence."
             },
-            "senderDetails": {
+            "SenderDetails": {
                 "$ref": "#/definitions/UserDetailsType",
                 "description": "Details of the message sender."
             },
-            "senderDelegateDetails": {
+            "SenderDelegateDetails": {
                 "$ref": "#/definitions/UserDetailsType",
                 "description": "Details of a delegate acting on behalf of the sender."
             },
-            "recipientDetails": {
+            "RecipientDetails": {
                 "type": "array",
                 "description": "One or more recipients of the message.",
                 "items": {
@@ -1272,7 +1228,7 @@
                 },
                 "minItems": 1
             },
-            "recipientsDelegateDetails": {
+            "RecipientsDelegateDetails": {
                 "type": "array",
                 "description": "Zero or more delegates acting on behalf of recipients.",
                 "items": {
@@ -1284,7 +1240,7 @@
                             "type": "object",
                             "description": "Extends UserDetailsType with the list of recipients for whom this delegate acts.",
                             "properties": {
-                                "delegatingRecipients": {
+                                "DelegatingRecipients": {
                                     "type": "array",
                                     "items": {
                                         "type": "integer"
@@ -1293,113 +1249,59 @@
                                 }
                             },
                             "required": [
-                                "delegatingRecipients"
+                                "DelegatingRecipients"
                             ]
                         }
                     ]
                 }
             },
-            "submissionTime": {
+            "SubmissionTime": {
                 "type": "string",
                 "format": "date-time",
                 "description": "Time at which the message was submitted."
             },
-            "evidenceRefersToRecipient": {
+            "EvidenceRefersToRecipient": {
                 "type": "integer",
                 "description": "1-based index into recipientDetails identifying the specific recipient this evidence pertains to."
             },
-            "messageIdentifier": {
+            "MessageIdentifier": {
                 "type": "string",
                 "minLength": 1,
                 "description": "Non-empty string identifying the message."
             },
-            "userContentInfo": {
-                "type": "object",
+            "UserContentInfo": {
+                "$ref": "#/definitions/UserContentInfoType",
                 "description": "Metadata about the user message content.",
-                "properties": {
-                    "appLayerIdentifier": {
-                        "type": "string",
-                        "description": "Optional application-layer identifier for the message."
-                    },
-                    "composingParts": {
-                        "type": "integer",
-                        "description": "Optional total number of parts composing the message."
-                    },
-                    "partsInfo": {
-                        "type": "array",
-                        "description": "One or more partInfo elements describing individual content parts.",
-                        "minItems": 1,
-                        "items": {
-                            "type": "object",
-                            "description": "Metadata for a single content part, including an optional digest.",
-                            "properties": {
-                                "identifier": {
-                                    "type": "string",
-                                    "description": "Identifier for this content part."
-                                },
-                                "contentType": {
-                                    "type": "string",
-                                    "description": "MIME type or other content type designation."
-                                },
-                                "digestMethod": {
-                                    "type": "object",
-                                    "description": "Algorithm used to compute the digest (ds:DigestMethod).",
-                                    "properties": {
-                                        "algorithm": {
-                                            "type": "string",
-                                            "format": "uri"
-                                        }
-                                    },
-                                    "required": [
-                                        "algorithm"
-                                    ]
-                                },
-                                "digestValue": {
-                                    "type": "string",
-                                    "contentEncoding": "base64",
-                                    "description": "Base64-encoded digest value (ds:DigestValue)."
-                                }
-                            },
-                            "required": [
-                                "identifier",
-                                "contentType"
-                            ]
-                        }
-                    }
-                },
-                "required": [
-                    "partsInfo"
-                ],
                 "examples": [
                     {
-                        "appLayerIdentifier": "contract",
-                        "composingParts": 1,
-                        "partsInfo": [
+                        "AppLayerIdentifier": "contract",
+                        "ComposingParts": 1,
+                        "PartsInfo": [
                             {
-                                "identifier": "contract.pdf",
-                                "contentType": "application/pdf",
-                                "digestMethod": {
-                                    "algorithm": "http://www.w3.org/2001/04/xmlenc#sha256"
+                                "Identifier": "contract.pdf",
+                                "ContentType": "application/pdf",
+                                "DigestMethod": {
+                                    "Algorithm": "http://www.w3.org/2001/04/xmlenc#sha256"
                                 },
-                                "digestValue": "ZXhhbXBsZWRpZ2VzdHZhbHVlZm9yY29udHJhY3RwZGY="
+                                "DigestValue": "ZXhhbXBsZWRpZ2VzdHZhbHVlZm9yY29udHJhY3RwZGY="
                             }
                         ]
                     }
                 ]
             },
-            "externalErdsDetails": {
+            "ExternalERDSDetails": {
                 "$ref": "#/definitions/EntityDetailsType",
                 "description": "Details of an external ERDS involved in the delivery."
             },
-            "forwardedToExternalSystem": {
+            "ForwardedToExternalSystem": {
                 "type": "string",
                 "description": "Identifier of an external system to which the message was forwarded."
             },
-            "transactionLogInformation": {
+            "TransactionLogInformation": {
                 "type": "object",
                 "description": "References to one or more external transaction logs.",
                 "properties": {
-                    "transactionLog": {
+                    "TransactionLog": {
                         "type": "array",
                         "items": {},
                         "minItems": 1,
@@ -1407,16 +1309,15 @@
                     }
                 },
                 "required": [
-                    "transactionLog"
+                    "TransactionLog"
                 ]
             },
-            "extensions": {
+            "Extensions": {
                 "type": "array",
                 "description": "One or more extension elements.",
                 "minItems": 1,
                 "items": {
                     "allOf": [
-                        {},
                         {
                             "type": "object",
                             "description": "Extension element with an optional criticality flag (isCritical XML attribute).",
@@ -1436,20 +1337,53 @@
             }
         },
         "required": [
-            "eventTime",
-            "evidenceIssuerDetails",
-            "senderDetails",
-            "recipientDetails"
+            "EventTime",
+            "EvidenceIssuerDetails",
+            "SenderDetails",
+            "RecipientDetails"
         ]
     },
-    "Evidence": {
+    "EvidenceIdentifier": {
+        "type": "string",
+        "description": "String identifier for an evidence instance. Corresponds to the global XSD element EvidenceIdentifier (xs:string)."
+    },
+    "ERDSEventId": {
         "allOf": [
             {
-                "type": "object",
-                "description": "Bundled root schema for Evidence, corresponding to the global Evidence element."
+                "$ref": "#/definitions/NonEmptyURIType"
+            }
+        ],
+        "description": "URI identifying the ERDS event that triggered production of an evidence (Table 2). Corresponds to the global XSD element ERDSEventId (NonEmptyURIType)."
+    },
+    "Evidence": {
+        "type": "object",
+        "description": "JSON projection of the XSD Evidence element (EvidenceType) from ETSI EN 319 522-3 V1.2.1.",
+        "allOf": [
+            {
+                "properties": {
+                    "version": {
+                        "const": "EN319522v1.1.1",
+                        "description": "Required version attribute (shall be 'EN319522v1.1.1' per §5.2.2.3)."
+                    },
+                    "Id": {
+                        "type": "string",
+                        "description": "Optional Id attribute (xs:ID)."
+                    },
+                    "EvidenceIdentifier": {
+                        "$ref": "#/definitions/EvidenceIdentifier"
+                    },
+                    "ERDSEventId": {
+                        "$ref": "#/definitions/ERDSEventId"
+                    }
+                },
+                "required": [
+                    "version",
+                    "EvidenceIdentifier",
+                    "ERDSEventId"
+                ]
             },
             {
-                "$ref": "#"
+                "$ref": "#/definitions/Components"
             }
         ]
     },

--- a/docs/qerds/data-schemas/erds-evidence.json
+++ b/docs/qerds/data-schemas/erds-evidence.json
@@ -17,6 +17,10 @@
       "type": "string",
       "description": "String identifier for this evidence instance."
     },
+    "ERDSEventId": {
+      "$ref": "#/definitions/ERDSEventId",
+      "description": "URI identifying the ERDS event that triggered production of this evidence (Table 2 of ETSI EN 319 522-3)."
+    },
     "EventReasons": {
       "type": "object",
       "description": "Container for one or more event reasons.",


### PR DESCRIPTION
Since ETSI [TR 119 520-1](https://www.etsi.org/deliver/etsi_tr/119500_119599/11952001/01.01.01_60/tr_11952001v010101p.pdf) proposes JSON evidence rather than XML evidence, and we need to specify a common WE BUILD profile anyway, I suggest to start with JSON and assume the use of JAdES (ETSI TS 119 182-1) instead of XML Signature.

Structurally equivalent to the EvidenceType XML Schema in ETSI EN 319 522-3 V1.2.1. Covers all evidence fields, event IDs from Table 2, entity/user/assurance/authentication detail types, and an example PDF contract in userContentInfo.